### PR TITLE
Zeppelin Solidity Hot Loader integration for ZepKit

### DIFF
--- a/client/config-overrides.js
+++ b/client/config-overrides.js
@@ -1,5 +1,4 @@
 /* config-overrides.js */
-// const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 
 module.exports = function override(config, env) {
   //do stuff with the webpack config...
@@ -19,7 +18,13 @@ module.exports = function override(config, env) {
         { loader: 'json-loader' },
         {
           loader: 'zeppelin-solidity-hot-loader',
-          options: { network: 'development'},
+          options: {
+            network: 'development',
+            // you can stop loader from automatic compile/push/updgrade
+            // action by setting disabled flag to true, but it will still
+            // serve .json files from file system
+            disabled: false,
+          },
         },
       ],
     }

--- a/client/config-overrides.js
+++ b/client/config-overrides.js
@@ -15,7 +15,13 @@ module.exports = function override(config, env) {
   config.module.rules.splice(config.module.rules - 2, 0,
     {
       test: /\.sol$/,
-      use: [ { loader: 'json-loader' }, { loader: 'zeppelin-solidity-hot-loader' } ],
+      use: [ 
+        { loader: 'json-loader' },
+        {
+          loader: 'zeppelin-solidity-hot-loader',
+          options: { network: 'development'},
+        },
+      ],
     }
   );
 

--- a/client/config-overrides.js
+++ b/client/config-overrides.js
@@ -1,4 +1,5 @@
 /* config-overrides.js */
+const { zeppelinSolidityHotLoader } = require('./config/webpack');
 
 module.exports = function override(config, env) {
   //do stuff with the webpack config...
@@ -11,24 +12,7 @@ module.exports = function override(config, env) {
 
   // add Zeppelin Solidity hot reloading support
   // have to insert before last loader, because CRA user 'file-loader' as default one
-  config.module.rules.splice(config.module.rules - 2, 0,
-    {
-      test: /\.sol$/,
-      use: [ 
-        { loader: 'json-loader' },
-        {
-          loader: 'zeppelin-solidity-hot-loader',
-          options: {
-            network: 'development',
-            // you can stop loader from automatic compile/push/updgrade
-            // action by setting disabled flag to true, but it will still
-            // serve .json files from file system
-            disabled: false,
-          },
-        },
-      ],
-    }
-  );
+  config.module.rules.splice(config.module.rules - 2, 0, zeppelinSolidityHotLoader);
 
   return config;
 }

--- a/client/config-overrides.js
+++ b/client/config-overrides.js
@@ -1,0 +1,23 @@
+/* config-overrides.js */
+// const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
+
+module.exports = function override(config, env) {
+  //do stuff with the webpack config...
+
+  // allow importing from outside of app/src folder, ModuleScopePlugin prevents this.
+  const scope = config.resolve.plugins.findIndex(o => o.constructor.name === 'ModuleScopePlugin');
+  if (scope > -1) {
+    config.resolve.plugins.splice(scope, 1);
+  }
+
+  // add Zeppelin Solidity hot reloading support
+  // have to insert before last loader, because CRA user 'file-loader' as default one
+  config.module.rules.splice(config.module.rules - 2, 0,
+    {
+      test: /\.sol$/,
+      use: [ { loader: 'json-loader' }, { loader: 'zeppelin-solidity-hot-loader' } ],
+    }
+  );
+
+  return config;
+}

--- a/client/config/webpack.js
+++ b/client/config/webpack.js
@@ -1,0 +1,21 @@
+const zeppelinSolidityHotLoaderOptions = {
+  network: 'development',
+  // you can stop loader from automatic compile/push/updgrade
+  // action by setting disabled flag to true, but it will still
+  // serve .json files from file system
+  disabled: false,
+}
+
+module.exports = {
+  zeppelinSolidityHotLoader: {
+      test: /\.sol$/,
+      use: [ 
+        { loader: 'json-loader' },
+        {
+          loader: 'zeppelin-solidity-hot-loader',
+          options: zeppelinSolidityHotLoaderOptions,
+        },
+      ],
+    },
+  zeppelinSolidityHotLoaderOptions,
+};

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3402,6 +3402,19 @@
         "typedarray": "^0.0.6"
       }
     },
+    "configstore": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+      "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+      "requires": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
+    },
     "confusing-browser-globals": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.5.tgz",
@@ -3579,6 +3592,11 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "css-color-keywords": {
       "version": "1.0.0",
@@ -6322,7 +6340,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6340,11 +6359,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6357,15 +6378,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6468,7 +6492,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6478,6 +6503,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6490,17 +6516,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6517,6 +6546,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6589,7 +6619,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6599,6 +6630,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6674,7 +6706,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6704,6 +6737,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6721,6 +6755,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6759,11 +6794,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -9339,6 +9376,11 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
+    "json-loader": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -10625,6 +10667,11 @@
       "requires": {
         "url-parse": "^1.4.3"
       }
+    },
+    "original-require": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
+      "integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA="
     },
     "os-browserify": {
       "version": "0.3.0",
@@ -14802,6 +14849,23 @@
         }
       }
     },
+    "react-app-rewired": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.0.tgz",
+      "integrity": "sha512-eq0okL3shrAsg0u8HQQA1bYk/He/j4vNEQWZJyVZN7Lpb0/TOHSR0kyo8geGecIlUfgR0ABlw2X9sdxgm/beKQ==",
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "dotenv": "^6.2.0",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+          "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+        }
+      }
+    },
     "react-dev-utils": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-7.0.1.tgz",
@@ -17634,6 +17698,73 @@
         "glob": "^7.1.2"
       }
     },
+    "truffle-config": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.1.4.tgz",
+      "integrity": "sha512-8ur8gYIUWBV8VN+JH4vRX2rk1pHmW+vpylPO2LT6HHWsRm6GbkPjeIjtGM70pR4DoihEJH0ZgJn14zLef83SVQ==",
+      "requires": {
+        "configstore": "^4.0.0",
+        "find-up": "^2.1.0",
+        "lodash": "4.17.11",
+        "original-require": "1.0.1",
+        "truffle-error": "^0.0.4",
+        "truffle-provider": "^0.1.4"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        }
+      }
+    },
+    "truffle-error": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.4.tgz",
+      "integrity": "sha512-hER0TNR4alBIhUp7SNrZRRiZtM/MBx+xBdM9qXP0tC3YASFmhNAxPuOyB8JDHFRNbDx12K7nvaqmyYGsI5c8BQ=="
+    },
+    "truffle-provider": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.1.4.tgz",
+      "integrity": "sha512-BE/3yhtarBqv5/o43UpwZ1ym2lQuF37cCpTBcHhb814T9iv5qXr8AsuwRhJSm/9x+Nu4wOvdd8TWzZeltjVdZQ==",
+      "requires": {
+        "truffle-error": "^0.0.4",
+        "web3": "1.0.0-beta.37"
+      }
+    },
     "tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -17948,6 +18079,14 @@
       "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
       "requires": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "requires": {
+        "crypto-random-string": "^1.0.0"
       }
     },
     "unist-util-stringify-position": {
@@ -18510,7 +18649,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       }
     },
     "web3-shh": {
@@ -19377,6 +19516,11 @@
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+    },
     "xhr": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
@@ -19493,6 +19637,15 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "zeppelin-solidity-hot-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/zeppelin-solidity-hot-loader/-/zeppelin-solidity-hot-loader-1.0.0.tgz",
+      "integrity": "sha512-4jLoYIwoaDCogMYYZ8eGg327iJ0kthep8kIzPpdhiw9pnqVNRSi+EG+QBt9ZRIydgM48Rp5aC29Mz3nzifFpUQ==",
+      "requires": {
+        "find-up": "^3.0.0",
+        "truffle-config": "^1.1.4"
       }
     }
   }

--- a/client/package.json
+++ b/client/package.json
@@ -4,18 +4,21 @@
   "private": true,
   "dependencies": {
     "classnames": "^2.2.6",
+    "json-loader": "^0.5.7",
     "node-sass": "^4.11.0",
     "react": "^16.7.0",
+    "react-app-rewired": "^2.1.0",
     "react-dom": "^16.7.0",
     "react-scripts": "2.1.3",
     "rimble-ui": "^0.2.0",
     "styled-components": "^4.1.3",
-    "web3": "1.0.0-beta.37"
+    "web3": "1.0.0-beta.37",
+    "zeppelin-solidity-hot-loader": "^1.0.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -26,5 +29,6 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "devDependencies": {}
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,6 +9,8 @@ import Wallet from "./components/Wallet/index.js";
 import Instructions from "./components/Instructions/index.js";
 import { Loader } from 'rimble-ui';
 
+import { zeppelinSolidityHotLoaderOptions } from '../config/webpack';
+
 import styles from './App.module.scss';
 
 class App extends Component {
@@ -31,6 +33,7 @@ class App extends Component {
   }
 
   componentDidMount = async () => {
+    const hotLoaderDisabled = zeppelinSolidityHotLoaderOptions.disabled;
     let Counter = {};
     let Wallet = {};
     try {
@@ -54,6 +57,7 @@ class App extends Component {
         const accounts = await web3.eth.getAccounts();
         // Get the contract instance.
         const networkId = await web3.eth.net.getId();
+        const networkType = await web3.eth.net.getNetworkType();
         const isMetaMask = web3.currentProvider.isMetaMask;
         let balance = accounts.length > 0 ? await web3.eth.getBalance(accounts[0]): web3.utils.toWei('0');
         balance = web3.utils.fromWei(balance, 'ether');
@@ -81,7 +85,7 @@ class App extends Component {
         if (instance || instanceWallet) {
           // Set web3, accounts, and contract to the state, and then proceed with an
           // example of interacting with the contract's methods.
-          this.setState({ web3, ganacheAccounts, accounts, balance, networkId,
+          this.setState({ web3, ganacheAccounts, accounts, balance, networkId, networkType, hotLoaderDisabled,
             isMetaMask, contract: instance, wallet: instanceWallet }, () => {
               this.refreshValues(instance, instanceWallet);
               setInterval(() => {
@@ -90,7 +94,7 @@ class App extends Component {
             });
         }
         else {
-          this.setState({ web3, ganacheAccounts, accounts, balance, networkId, isMetaMask });
+          this.setState({ web3, ganacheAccounts, accounts, balance, networkId, networkType, hotLoaderDisabled, isMetaMask });
         }
       }
     } catch (error) {
@@ -179,6 +183,8 @@ class App extends Component {
   }
 
   renderBody() {
+    const { hotLoaderDisabled, networkType, accounts, ganacheAccounts } = this.state;
+    const updgradeCommand = (networkType === 'private' && !hotLoaderDisabled) ? "upgrade-auto" : "upgrade";
     return (
       <div className={styles.wrapper}>
         {!this.state.web3 && this.renderLoader()}
@@ -199,13 +205,15 @@ class App extends Component {
             </div>
             {this.state.balance < 0.1 && (
               <Instructions
-                ganacheAccounts={this.state.ganacheAccounts}
-                name="metamask" accounts={this.state.accounts} />
+                ganacheAccounts={ganacheAccounts}
+                name="metamask"
+                accounts={accounts} />
             )}
             {this.state.balance >= 0.1 && (
               <Instructions
                 ganacheAccounts={this.state.ganacheAccounts}
-                name="upgrade" accounts={this.state.accounts} />
+                name={updgradeCommand}
+                accounts={accounts} />
             )}
           </div>
         )}

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -34,8 +34,8 @@ class App extends Component {
     let Counter = {};
     let Wallet = {};
     try {
-      Counter = require("./contracts/Counter.json");
-      Wallet = require("./contracts/Wallet.json");
+      Counter = require("../../contracts/Counter.sol");
+      Wallet = require("../../contracts/Wallet.sol");
     } catch (e) {
       console.log(e);
     }

--- a/client/src/components/Instructions/index.js
+++ b/client/src/components/Instructions/index.js
@@ -266,6 +266,33 @@ export default class Instructions extends Component {
             Reload
           </Button>
         </div>
+        <h2> Upgrading on Development Network </h2>
+        <p> Thanks to ZeppelinOS and Solidity Hot Loader your smart contracts would reload automatically after you save a .sol file while preserving state. </p>
+        <div className={styles.step}>
+          <div className={styles.instruction}>
+            1. Open <span>contracts/Counter.sol</span> and uncomment the decreaseCounter method (lines 32-36).
+          </div>
+          <div className={styles.code}>
+            <code>
+              {`// function decreaseCounter(uint256 amount) public returns (bool) {`}
+            </code>
+          </div>
+        </div>
+        <div className={styles.step}>
+          <div className={styles.instruction}>
+            2. Save the changes and wait for .sol files compilation, ZOS commands automatically executed.
+          </div>
+        </div>
+        <div className={styles.step}>
+          <div className={styles.instruction}>
+            3. Once compilation, push, and update commands are completed, your changes would be loaded.
+          </div>
+        </div>
+        <div className={styles.step}>
+          <div className={styles.instruction}>
+            4. Congratulations! You have upgraded your contract and you can now decrease the counter.
+          </div>
+        </div>
       </div>
     );
   }

--- a/client/src/components/Instructions/index.js
+++ b/client/src/components/Instructions/index.js
@@ -266,8 +266,15 @@ export default class Instructions extends Component {
             Reload
           </Button>
         </div>
+      </div>
+    );
+  }
+
+  renderAutoUpgrade() {
+    return (
+      <div className={styles.instructions}>
         <h2> Upgrading on Development Network </h2>
-        <p> Thanks to ZeppelinOS and Solidity Hot Loader your smart contracts would reload automatically after you save a .sol file while preserving state. </p>
+        <p> Thanks to ZeppelinOS and Solidity Hot Loader your smart contracts would reload automatically after you save a .sol file while preserving a state. </p>
         <div className={styles.step}>
           <div className={styles.instruction}>
             1. Open <span>contracts/Counter.sol</span> and uncomment the decreaseCounter method (lines 32-36).
@@ -280,19 +287,16 @@ export default class Instructions extends Component {
         </div>
         <div className={styles.step}>
           <div className={styles.instruction}>
-            2. Save the changes and wait for .sol files compilation, ZOS commands automatically executed.
+            2. Save the changes and wait for the .sol files to compile. Upon completion, ZOS will push and update your smart contracts
           </div>
         </div>
         <div className={styles.step}>
           <div className={styles.instruction}>
-            3. Once compilation, push, and update commands are completed, your changes would be loaded.
+            3. Congratulations! You have upgraded your contract and you can now decrease the counter.
           </div>
         </div>
-        <div className={styles.step}>
-          <div className={styles.instruction}>
-            4. Congratulations! You have upgraded your contract and you can now decrease the counter.
-          </div>
-        </div>
+        <div className={styles.separator} />
+        <p> * On a non development network you would have to run <strong>zos push</strong> and <strong>zos update</strong> commands manually. </p>
       </div>
     );
   }
@@ -467,6 +471,8 @@ export default class Instructions extends Component {
         return this.renderMetamask();
       case 'upgrade':
         return this.renderUpgrade();
+      case 'upgrade-auto':
+        return this.renderAutoUpgrade();
       case 'counter':
         return this.renderCounterSetup();
       case 'faq':

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,18 +4,70 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/runtime": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
-      "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+    "@resolver-engine/core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",
+      "integrity": "sha512-nsLQHmPJ77QuifqsIvqjaF5B9aHnDzJjp73Q1z6apY3e9nqYrx4Dtowhpsf7Jwftg/XzVDEMQC+OzUBNTS+S1A==",
       "requires": {
-        "regenerator-runtime": "^0.12.0"
+        "debug": "^3.1.0",
+        "request": "^2.85.0"
+      }
+    },
+    "@resolver-engine/fs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.2.1.tgz",
+      "integrity": "sha512-7kJInM1Qo2LJcKyDhuYzh9ZWd+mal/fynfL9BNjWOiTcOpX+jNfqb/UmGUqros5pceBITlWGqS4lU709yHFUbg==",
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0"
+      }
+    },
+    "@resolver-engine/imports": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.2.2.tgz",
+      "integrity": "sha512-u5/HUkvo8q34AA+hnxxqqXGfby5swnH0Myw91o3Sm2TETJlNKXibFGSKBavAH+wvWdBi4Z5gS2Odu0PowgVOUg==",
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0",
+        "hosted-git-info": "^2.6.0"
+      }
+    },
+    "@resolver-engine/imports-fs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.2.2.tgz",
+      "integrity": "sha512-gFCgMvCwyppjwq0UzIjde/WI+yDs3oatJhozG9xdjJdewwtd7LiF0T5i9lrHAUtqrQbqoFE4E+ZMRVHWpWHpKQ==",
+      "requires": {
+        "@resolver-engine/fs": "^0.2.1",
+        "@resolver-engine/imports": "^0.2.2",
+        "debug": "^3.1.0"
+      }
+    },
+    "@types/bn.js": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.4.tgz",
+      "integrity": "sha512-AO8WW+aRcKWKQAYTfKLzwnpL6U+TfPqS+haRrhCy5ff04Da8WZud3ZgVjspQXaEXJDcTlsjUEVvL39wegDek5w==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "10.12.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.19.tgz",
-      "integrity": "sha512-2NVovndCjJQj6fUUn9jCgpP4WSqr+u1SoUZMZyJkhGeBFsm6dE46l31S7lPUYt9uQ28XI+ibrJA1f5XyH5HNtA=="
+      "version": "11.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.4.tgz",
+      "integrity": "sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA=="
+    },
+    "@types/underscore": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.9.tgz",
+      "integrity": "sha512-vfzZGgZKRFy7KEWcBGfIFk+h6B+thDCLfkD1exMBMRlUsx2icA+J6y4kAbZs/TjSTeY1duw89QUU133TSzr60Q=="
+    },
+    "@types/web3": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@types/web3/-/web3-1.0.18.tgz",
+      "integrity": "sha512-uXQL0LDszt2f476LEmYM6AvSv9F4vU4hWQvlUhwfLHNlIB6OyBXoYsCzWAIhhnc5U0HA7ZBcPybxRJ/yfA6THg==",
+      "requires": {
+        "@types/bn.js": "*",
+        "@types/underscore": "*"
+      }
     },
     "accepts": {
       "version": "1.3.5",
@@ -32,20 +84,15 @@
       "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+      "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
-    },
-    "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -59,11 +106,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
-    },
-    "app-module-path": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
-      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -92,14 +134,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-      "requires": {
-        "lodash": "^4.17.10"
-      }
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -161,14 +195,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -176,6 +202,14 @@
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -228,11 +262,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
-    },
-    "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -355,11 +384,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
-    "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -373,12 +397,22 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
-    },
-    "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -388,26 +422,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-      "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -431,30 +445,14 @@
       }
     },
     "commander": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-      "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-      "requires": {
-        "graceful-readlink": ">= 1.0.0"
-      }
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "configstore": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
-      "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
-      "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      }
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -529,16 +527,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -557,16 +545,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "crypto-js": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
-      "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
-    },
-    "crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -582,11 +560,6 @@
       "requires": {
         "ms": "2.0.0"
       }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -606,13 +579,6 @@
         "make-dir": "^1.0.0",
         "pify": "^2.3.0",
         "strip-dirs": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
       }
     },
     "decompress-response": {
@@ -678,11 +644,23 @@
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
         },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        "get-stream": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
         }
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
       }
     },
     "delayed-stream": {
@@ -709,11 +687,6 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
-    "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
-    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -729,28 +702,10 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
       "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
-    "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-      "requires": {
-        "is-obj": "^1.0.0"
-      }
-    },
     "dotenv": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
       "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
-    },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -772,17 +727,14 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elliptic": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+      "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "inherits": "^2.0.1"
       }
     },
     "encodeurl": {
@@ -796,6 +748,29 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-html": {
@@ -820,13 +795,6 @@
       "requires": {
         "idna-uts46-hx": "^2.3.1",
         "js-sha3": "^0.5.7"
-      },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        }
       }
     },
     "eth-lib": {
@@ -841,35 +809,28 @@
         "servify": "^0.1.12",
         "ws": "^3.0.0",
         "xhr-request-promise": "^0.1.2"
-      }
-    },
-    "ethereumjs-abi": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.6.tgz",
-      "integrity": "sha512-w8KubDsA/+OAuqtIR9RGsMcoZ5nhM8vxwjJAJvEIY+clhxA3BHoLG3+ClYQaQhD0n3mlDt3U5rBrmSVJvI3c8A==",
-      "requires": {
-        "bn.js": "^4.10.0",
-        "ethereumjs-util": "^5.0.0"
-      }
-    },
-    "ethereumjs-util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-      "requires": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "ethjs-util": "^0.1.3",
-        "keccak": "^1.0.2",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1",
-        "secp256k1": "^3.0.1"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+          "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        }
       }
     },
     "ethers": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.23.tgz",
-      "integrity": "sha512-9IwYV3LuESPF2cgwF42SL2vqrwWEsA2+15WVtO2dZb1F/twARaCWb7PrgoODldj+bmwKmUv3rG9PFfBkbumPwA==",
+      "version": "4.0.26",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.26.tgz",
+      "integrity": "sha512-3hK4S8eAGhuWZ/feip5z17MswjGgjb4lEPJqWO/O0dNqToYLSHhvu6gGQPs8d9f+XfpEB2EYexfF0qjhWiZjUA==",
       "requires": {
         "@types/node": "^10.3.2",
         "aes-js": "3.0.0",
@@ -883,57 +844,10 @@
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
-        "elliptic": {
-          "version": "6.3.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "inherits": "^2.0.1"
-          }
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-        }
-      }
-    },
-    "ethjs-abi": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
-      "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "js-sha3": "0.5.5",
-        "number-to-bn": "1.7.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        "@types/node": {
+          "version": "10.12.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.26.tgz",
+          "integrity": "sha512-nMRqS+mL1TOnIJrL6LKJcNZPB8V3eTfRo9FQA2b5gDvrHurC8XbSA86KNe0dShlEL7ReWJv/OU9NL7Z0dnqWTg=="
         }
       }
     },
@@ -953,19 +867,10 @@
         }
       }
     },
-    "ethjs-util": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "requires": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
-      }
-    },
     "eventemitter3": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
+      "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -974,27 +879,6 @@
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        }
       }
     },
     "express": {
@@ -1060,9 +944,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -1125,11 +1009,26 @@
       }
     },
     "follow-redirects": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
-      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "requires": {
-        "debug": "=3.1.0"
+        "debug": "^3.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "for-each": {
@@ -1170,22 +1069,26 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
-    "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+    "fs-promise": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
+      "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
-    "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-      "requires": {
-        "minipass": "^2.2.1"
+        "any-promise": "^1.3.0",
+        "fs-extra": "^2.0.0",
+        "mz": "^2.6.0",
+        "thenify-all": "^1.6.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0"
+          }
+        }
       }
     },
     "fs.realpath": {
@@ -1193,19 +1096,26 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "get-stream": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-      "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-      "requires": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getpass": {
       "version": "0.1.7",
@@ -1213,19 +1123,6 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
       }
     },
     "global": {
@@ -1256,13 +1153,6 @@
         "timed-out": "^4.0.0",
         "url-parse-lax": "^1.0.0",
         "url-to-options": "^1.0.1"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        }
       }
     },
     "graceful-fs": {
@@ -1274,11 +1164,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-    },
-    "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -1292,40 +1177,25 @@
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
-          "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        }
       }
     },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
       "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
@@ -1345,18 +1215,13 @@
       }
     },
     "hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
         "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
+        "minimalistic-assert": "^1.0.0"
       }
-    },
-    "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -1367,6 +1232,11 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
     },
     "http-errors": {
       "version": "1.6.3",
@@ -1422,11 +1292,6 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
       "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
     },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1440,11 +1305,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ipaddr.js": {
       "version": "1.8.0",
@@ -1461,10 +1321,10 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-function": {
       "version": "1.0.1",
@@ -1481,11 +1341,6 @@
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
     },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-    },
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
@@ -1495,6 +1350,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "^1.0.1"
+      }
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -1506,6 +1369,14 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -1515,11 +1386,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
@@ -1536,9 +1402,9 @@
       }
     },
     "js-sha3": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-      "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
     "jsbn": {
       "version": "0.1.1",
@@ -1551,9 +1417,9 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -1561,9 +1427,9 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -1579,17 +1445,6 @@
         "verror": "1.10.0"
       }
     },
-    "keccak": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-      "requires": {
-        "bindings": "^1.2.1",
-        "inherits": "^2.0.3",
-        "nan": "^2.2.1",
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "keccakjs": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
@@ -1597,22 +1452,6 @@
       "requires": {
         "browserify-sha3": "^0.0.4",
         "sha3": "^1.2.2"
-      }
-    },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "requires": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "^1.0.0"
       }
     },
     "locate-path": {
@@ -1624,31 +1463,110 @@
         "path-exists": "^3.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    "lodash.concat": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.concat/-/lodash.concat-4.5.0.tgz",
+      "integrity": "sha1-sFOuAuSoAIWC5yVrnQK9ptA4A5U="
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
+    "lodash.every": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.every/-/lodash.every-4.6.0.tgz",
+      "integrity": "sha1-64mYS+vENkJ5uzrvu9HKGb+mxqc="
+    },
+    "lodash.findlast": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.findlast/-/lodash.findlast-4.6.0.tgz",
+      "integrity": "sha1-6ou3jPLn54BPyK630ZU+B/4x+8g="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.invertby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.invertby/-/lodash.invertby-4.7.0.tgz",
+      "integrity": "sha1-zeu2zUlCqmuN8sdL4cXZSGgnGLA="
+    },
+    "lodash.isarray": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
+      "integrity": "sha1-KspJayjEym1yZxUxNZDALm6jRAM="
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU="
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.reverse": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.reverse/-/lodash.reverse-4.0.1.tgz",
+      "integrity": "sha1-Hyr+2s4uFuZg86p8WdMwCm8l0Tw="
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "lodash.values": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
+    },
+    "lodash.without": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
     },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        }
-      }
     },
     "make-dir": {
       "version": "1.3.0",
@@ -1656,6 +1574,13 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
         "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
       }
     },
     "md5.js": {
@@ -1672,19 +1597,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
-    "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "requires": {
-        "mimic-fn": "^1.0.0"
-      }
-    },
-    "memorystream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -1711,22 +1623,17 @@
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "~1.38.0"
       }
-    },
-    "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -1764,23 +1671,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
-    "minipass": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-      "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
-      "requires": {
-        "minipass": "^2.2.1"
-      }
-    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -1797,65 +1687,30 @@
         "mkdirp": "*"
       }
     },
-    "mocha": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.11.0",
-        "debug": "3.1.0",
-        "diff": "3.3.1",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.3",
-        "he": "1.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "requires": {
-            "has-flag": "^2.0.0"
-          }
-        }
-      }
-    },
     "mock-fs": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.7.0.tgz",
-      "integrity": "sha512-WlQNtUlzMRpvLHf8dqeUmNqfdPjGY29KrJF50Ldb4AcL+vQeR8QH3wQcFMgrhTwb1gHjZn9xggho+84tBskLgA=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.8.0.tgz",
+      "integrity": "sha512-Gwj4KnJOW15YeTJKO5frFd/WDO5Mc0zxXqL9oHx3+e9rBqW8EVARqQHSaIXznUdljrD6pvbNGW2ZGXKPEfYJfw=="
+    },
+    "mout": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
+      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "nan": {
       "version": "2.12.1",
@@ -1871,19 +1726,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "^2.0.0"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "number-to-bn": {
       "version": "1.7.0",
@@ -1911,10 +1753,15 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
+    },
     "oboe": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
-      "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
+      "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
       "requires": {
         "http-https": "^1.0.0"
       }
@@ -1944,21 +1791,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
       "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg=="
-    },
-    "original-require": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
-      "integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA="
-    },
-    "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
-      }
     },
     "p-cancelable": {
       "version": "0.3.0",
@@ -2000,9 +1832,9 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "parse-asn1": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
-      "integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
+      "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
       "requires": {
         "asn1.js": "^4.0.0",
         "browserify-aes": "^1.0.0",
@@ -2013,12 +1845,12 @@
       }
     },
     "parse-headers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
-      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
+      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
       "requires": {
-        "for-each": "^0.3.2",
-        "trim": "0.0.1"
+        "for-each": "^0.3.3",
+        "string.prototype.trim": "^1.1.2"
       }
     },
     "parseurl": {
@@ -2035,11 +1867,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -2069,9 +1896,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -2109,11 +1936,6 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.1.31",
@@ -2153,15 +1975,10 @@
         "strict-uri-encode": "^1.0.0"
       }
     },
-    "querystringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
-    },
     "randombytes": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -2210,11 +2027,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-    },
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
@@ -2240,27 +2052,14 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
       }
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "rimraf": {
       "version": "2.6.3",
@@ -2268,6 +2067,21 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
         "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "ripemd160": {
@@ -2277,15 +2091,6 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
-      }
-    },
-    "rlp": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.2.tgz",
-      "integrity": "sha512-Ng2kJEN731Sfv4ZAY2i0ytPMc0BbJKBsVNl0QZY8LxOWSwd+1xpg+fpSRfaMn0heHU447s6Kgy8qfHZR0XTyVw==",
-      "requires": {
-        "bn.js": "^4.11.1",
-        "safe-buffer": "^5.1.1"
       }
     },
     "safe-buffer": {
@@ -2328,27 +2133,22 @@
         "pbkdf2": "^3.0.3"
       }
     },
-    "secp256k1": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.6.2.tgz",
-      "integrity": "sha512-90nYt7yb0LmI4A2jJs1grglkTAXrBwxYAjP9bpeKjvJKOjG2fOeH/YI/lchDMIvjrOasd5QXwvV2jwN168xNng==",
-      "requires": {
-        "bindings": "^1.2.1",
-        "bip66": "^1.1.3",
-        "bn.js": "^4.11.3",
-        "create-hash": "^1.1.2",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.2.3",
-        "nan": "^2.2.1",
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "seek-bzip": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "requires": {
         "commander": "~2.8.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        }
       }
     },
     "semver": {
@@ -2414,15 +2214,10 @@
         "xhr": "^2.3.3"
       }
     },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
     "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+      "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
     },
     "setprototypeof": {
       "version": "1.1.0",
@@ -2453,24 +2248,6 @@
         }
       }
     },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
     "simple-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
@@ -2486,45 +2263,10 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "solc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.0.tgz",
-      "integrity": "sha512-mdLHDl9WeYrN+FIKcMc9PlPfnA9DG9ur5QpCDKcv6VC4RINAsTF4EMuXMZMKoQTvZhtLyJIVH/BZ+KU830Z8Xg==",
-      "requires": {
-        "fs-extra": "^0.30.0",
-        "keccak": "^1.0.2",
-        "memorystream": "^0.3.1",
-        "require-from-string": "^2.0.0",
-        "semver": "^5.5.0",
-        "yargs": "^11.0.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        }
-      }
-    },
     "solidity-parser-antlr": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.0.tgz",
-      "integrity": "sha512-RrIsh5VoHmrMQia6yLY8u8rx3JPREhSiCFz4Xb0h1Oh0prUYU2ukyWO8gG892V0UMHIXCWqvdZ3wSctNwdWThg=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.1.tgz",
+      "integrity": "sha512-3lXZd3kUbCyiLCieDeyhAm2jPtPXKQYVR5wItbVLRw4MW4fv5pSGC3v4x6BRucKVE6tjVZ9AhTErkqRu2KlXDg=="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -2552,13 +2294,14 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -2569,14 +2312,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "requires": {
-        "ansi-regex": "^3.0.0"
-      }
-    },
     "strip-dirs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
@@ -2584,11 +2319,6 @@
       "requires": {
         "is-natural-number": "^4.0.1"
       }
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-hex-prefix": {
       "version": "1.0.0",
@@ -2598,45 +2328,50 @@
         "is-hex-prefixed": "1.0.0"
       }
     },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
-    },
     "swarm-js": {
-      "version": "0.1.39",
-      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
-      "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
+      "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
       "requires": {
         "bluebird": "^3.5.0",
         "buffer": "^5.0.5",
         "decompress": "^4.0.0",
         "eth-lib": "^0.1.26",
-        "fs-extra": "^4.0.2",
+        "fs-extra": "^2.1.2",
+        "fs-promise": "^2.0.0",
         "got": "^7.1.0",
         "mime-types": "^2.1.16",
         "mkdirp-promise": "^5.0.1",
         "mock-fs": "^4.1.0",
         "setimmediate": "^1.0.5",
-        "tar": "^4.0.2",
+        "tar.gz": "^1.0.5",
         "xhr-request-promise": "^0.1.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0"
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+        }
       }
     },
     "tar": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.4",
-        "minizlib": "^1.1.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-stream": {
@@ -2651,6 +2386,41 @@
         "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
+      }
+    },
+    "tar.gz": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
+      "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
+      "requires": {
+        "bluebird": "^2.9.34",
+        "commander": "^2.8.1",
+        "fstream": "^1.0.8",
+        "mout": "^0.11.0",
+        "tar": "^2.1.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+        }
+      }
+    },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
       }
     },
     "through": {
@@ -2684,152 +2454,16 @@
         }
       }
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-    },
-    "truffle": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.2.tgz",
-      "integrity": "sha512-xBLTUqjYcJIQgEqXJ+j6AU6s+NaQZC+cTuEUhYbEIKhgQBKOczHMYSqf1UBtybq7Jqb2QChXQu82DqAfKC/z9A==",
-      "requires": {
-        "app-module-path": "^2.2.0",
-        "mocha": "^4.1.0",
-        "original-require": "1.0.1",
-        "solc": "0.5.0"
-      }
-    },
-    "truffle-blockchain-utils": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.5.tgz",
-      "integrity": "sha1-pOXAZNrdafeCoTfz0nbSEJXaekc="
-    },
-    "truffle-config": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.0.6.tgz",
-      "integrity": "sha1-GB2n0xnAxV6yeB1cGIapx/MvpHA=",
-      "requires": {
-        "find-up": "^2.1.0",
-        "lodash": "4.17.10",
-        "original-require": "1.0.1",
-        "truffle-error": "^0.0.3",
-        "truffle-provider": "^0.0.6"
-      }
-    },
-    "truffle-contract": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.6.tgz",
-      "integrity": "sha1-Lvb8Mtf6r6n0rtjlAAGp/eo0IZI=",
-      "requires": {
-        "ethjs-abi": "0.1.8",
-        "truffle-blockchain-utils": "^0.0.5",
-        "truffle-contract-schema": "^2.0.1",
-        "truffle-error": "^0.0.3",
-        "web3": "0.20.6"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-        },
-        "web3": {
-          "version": "0.20.6",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-          "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-          "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "^3.1.4",
-            "utf8": "^2.1.1",
-            "xhr2": "*",
-            "xmlhttprequest": "*"
-          }
-        }
-      }
-    },
-    "truffle-contract-schema": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.2.tgz",
-      "integrity": "sha512-8mYAu0Y7wgMqcIa612dxiN9pzr6rq2YxZCzPizvqyDq+/rGWy8s0irl/T7i92a/4ME1V5ddNFf3+86uIlYbPUg==",
-      "requires": {
-        "ajv": "^5.1.1",
-        "crypto-js": "^3.1.9-1",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "crypto-js": {
-          "version": "3.1.9-1",
-          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-          "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
-        }
-      }
-    },
-    "truffle-error": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.3.tgz",
-      "integrity": "sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o="
-    },
-    "truffle-expect": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/truffle-expect/-/truffle-expect-0.0.4.tgz",
-      "integrity": "sha1-1bJ63qTFUvQ7cNwAh3I2t7aMdcg="
-    },
     "truffle-flattener": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.2.11.tgz",
-      "integrity": "sha512-Y62qAC5qxxQ/gKtetWlH92uYodpONC1MLKuMtVgLvTtUHGkE0kypGZB9svUePCokuey4MHU5nLxwhk22lLeCiQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.3.0.tgz",
+      "integrity": "sha512-ppJ9xI0tDuvCYjQlcWwMBcOKZph5U4YpG/gChyUVDxOjUIniG5g7y9vZho2PRj1FohPPnOjg1KOAVNlk/bPZrw==",
       "requires": {
-        "chalk": "^2.4.2",
+        "@resolver-engine/imports-fs": "^0.2.2",
         "find-up": "^2.1.0",
         "mkdirp": "^0.5.1",
-        "semver": "^5.6.0",
         "solidity-parser-antlr": "^0.4.0",
-        "truffle-config": "^1.1.2",
-        "truffle-resolver": "^4.0.5",
         "tsort": "0.0.1"
-      },
-      "dependencies": {
-        "truffle-config": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.1.2.tgz",
-          "integrity": "sha512-TfvE5KCTZSXPfEZ8xgs25sOY7uR1xnE52dYPj+arLlaMw1UmMWcIts97HqqK+jVGeKlMPQu2/PwN5m18c+91Fg==",
-          "requires": {
-            "configstore": "^4.0.0",
-            "find-up": "^2.1.0",
-            "lodash": "4.17.10",
-            "original-require": "1.0.1",
-            "truffle-error": "^0.0.3",
-            "truffle-provider": "^0.1.2"
-          }
-        },
-        "truffle-provider": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.1.2.tgz",
-          "integrity": "sha512-UcHfKydFzZsVyX7uedbNduEU3Po0BlFUI4Sg4jpuLUQUkPZiY8UZkRLAdhBgwjP0W0AEDFtK8VCoffwUxNicQw==",
-          "requires": {
-            "truffle-error": "^0.0.3",
-            "web3": "^1.0.0-beta.37"
-          }
-        },
-        "web3": {
-          "version": "1.0.0-beta.41",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.41.tgz",
-          "integrity": "sha512-G4s5GBLP+xxwcIhevc4rmSg1PpQB/ou6KGCAR6UqGaRXNkSysjjifU1eywaCpcbjIN5FXjIOh/HGjVMdkt0VZQ==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "@types/node": "^10.12.18",
-            "web3-bzz": "1.0.0-beta.41",
-            "web3-core": "1.0.0-beta.41",
-            "web3-core-helpers": "1.0.0-beta.41",
-            "web3-core-method": "1.0.0-beta.41",
-            "web3-eth": "1.0.0-beta.41",
-            "web3-eth-personal": "1.0.0-beta.41",
-            "web3-net": "1.0.0-beta.41",
-            "web3-providers": "1.0.0-beta.41",
-            "web3-shh": "1.0.0-beta.41",
-            "web3-utils": "1.0.0-beta.41"
-          }
-        }
       }
     },
     "truffle-hdwallet-provider": {
@@ -2859,79 +2493,6 @@
             "nan": "^2.11.0",
             "typedarray-to-buffer": "^3.1.5",
             "yaeti": "^0.0.6"
-          }
-        }
-      }
-    },
-    "truffle-provider": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.0.6.tgz",
-      "integrity": "sha1-caku1nY2raXniQVpDXLqkirUphM=",
-      "requires": {
-        "truffle-error": "^0.0.3",
-        "web3": "0.20.6"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-        },
-        "web3": {
-          "version": "0.20.6",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-          "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-          "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "^3.1.4",
-            "utf8": "^2.1.1",
-            "xhr2": "*",
-            "xmlhttprequest": "*"
-          }
-        }
-      }
-    },
-    "truffle-provisioner": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/truffle-provisioner/-/truffle-provisioner-0.1.1.tgz",
-      "integrity": "sha1-WoMn1iUR7yPJUNOqhiYQp8N34qo="
-    },
-    "truffle-resolver": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/truffle-resolver/-/truffle-resolver-4.0.5.tgz",
-      "integrity": "sha512-aqPxo+bpL9yjfpSptvkV35WmkceBY4HbQGiUT2Rhx9cttNi0dQnPWL89inpQnBEqr1aLP9LxbZ+sai0PHKAD0w==",
-      "requires": {
-        "async": "2.6.1",
-        "truffle-contract": "^3.0.7",
-        "truffle-expect": "^0.0.4",
-        "truffle-provisioner": "^0.1.1"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-        },
-        "truffle-contract": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.7.tgz",
-          "integrity": "sha512-av4MTJDP29PI3oVh8TrvRzRHt+nZJH8ODSiil/TfcXrKMSes52DTA5LHj00siLvcadkxUgoEZfEZ04qqhNGoiA==",
-          "requires": {
-            "ethjs-abi": "0.1.8",
-            "truffle-blockchain-utils": "^0.0.5",
-            "truffle-contract-schema": "^2.0.2",
-            "truffle-error": "^0.0.3",
-            "web3": "0.20.6"
-          }
-        },
-        "web3": {
-          "version": "0.20.6",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-          "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-          "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "^3.1.4",
-            "utf8": "^2.1.1",
-            "xhr2": "*",
-            "xmlhttprequest": "*"
           }
         }
       }
@@ -2977,43 +2538,18 @@
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "unbzip2-stream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.1.tgz",
-      "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
       "requires": {
-        "buffer": "^3.0.1",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
-        },
-        "buffer": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-          "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
-          "requires": {
-            "base64-js": "0.0.8",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
-          }
-        }
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
-    "unique-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "requires": {
-        "crypto-random-string": "^1.0.0"
-      }
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -3026,15 +2562,6 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url-parse": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
-      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
-      "requires": {
-        "querystringify": "^2.0.0",
-        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {
@@ -3056,9 +2583,9 @@
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "utf8": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+      "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -3071,9 +2598,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
     },
     "vary": {
       "version": "1.1.2",
@@ -3091,362 +2618,321 @@
       }
     },
     "web3": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-      "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
+      "integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
       "requires": {
-        "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-        "crypto-js": "^3.1.4",
-        "utf8": "^2.1.1",
-        "xhr2": "*",
-        "xmlhttprequest": "*"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-          "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-        }
+        "web3-bzz": "1.0.0-beta.37",
+        "web3-core": "1.0.0-beta.37",
+        "web3-eth": "1.0.0-beta.37",
+        "web3-eth-personal": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37",
+        "web3-shh": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-bzz": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.41.tgz",
-      "integrity": "sha512-vLNYGlm3tmi31huIpQpizHxXw5yidx5FtF4zze5VsdMH3r7iVzuRjgShdB/XLUFvL7sdnJ0KNW2ULrScqaZ9aA==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.37.tgz",
+      "integrity": "sha512-E+dho49Nsm/QpQvYWOF35YDsQrMvLB19AApENxhlQsu6HpWQt534DQul0t3Y/aAh8rlKD6Kanxt8LhHDG3vejQ==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "@types/node": "^10.12.18",
-        "lodash": "^4.17.11",
-        "swarm-js": "^0.1.39"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
+        "got": "7.1.0",
+        "swarm-js": "0.1.37",
+        "underscore": "1.8.3"
       }
     },
     "web3-core": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.41.tgz",
-      "integrity": "sha512-giFB+1G6NyF0r8UAdmOf4j1d9uyrKjm38bz4KKVBGMaM87KvuDAtu0/1RajdPzpQZ3e424CV5VVSxibvVv5fEg==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.37.tgz",
+      "integrity": "sha512-cIwEqCj7OJyefQNauI0HOgW4sSaOQ98V99H2/HEIlnCZylsDzfw7gtQUdwnRFiIyIxjbWy3iWsjwDPoXNPZBYg==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "@types/node": "^10.12.18",
-        "lodash": "^4.17.11",
-        "web3-utils": "1.0.0-beta.41"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-requestmanager": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-core-helpers": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.41.tgz",
-      "integrity": "sha512-dYUYkN8XjSfAOeok8Od4nkzTWVnzKx65bPTJ+aUKuIegZ2qEuzwu6Aalfy09MGxs9tlylkblTg6nk1t7YoOgcQ==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.37.tgz",
+      "integrity": "sha512-efaLOzN28RMnbugnyelgLwPWWaSwElQzcAJ/x3PZu+uPloM/lE5x0YuBKvIh7/PoSMlHqtRWj1B8CpuQOUQ5Ew==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "lodash": "^4.17.11",
-        "web3-eth-iban": "1.0.0-beta.41",
-        "web3-utils": "1.0.0-beta.41"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
+        "underscore": "1.8.3",
+        "web3-eth-iban": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-core-method": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.41.tgz",
-      "integrity": "sha512-+E70WoTqExXRJRIOBRo4KJVArhR8o5Zh38djQjo/Ddaj5Eu7KiiPTK0z0axXjUQnFyrQbbb1nUmbBJboVxgvKA==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.37.tgz",
+      "integrity": "sha512-pKWFUeqnVmzx3VrZg+CseSdrl/Yrk2ioid/HzolNXZE6zdoITZL0uRjnsbqXGEzgRRd1Oe/pFndpTlRsnxXloA==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "eventemitter3": "3.1.0",
-        "web3-core": "1.0.0-beta.41",
-        "web3-core-helpers": "1.0.0-beta.41",
-        "web3-core-promievent": "1.0.0-beta.41",
-        "web3-core-subscriptions": "1.0.0-beta.41",
-        "web3-utils": "1.0.0-beta.41"
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-promievent": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-core-promievent": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.41.tgz",
-      "integrity": "sha512-0ByKXY26lGRKHz05MtqiZwB5cILvdTbNlUdQU94lMFm2KD5XKRvoQjeRAnugr07d8L2q+3LIU1vIGy/OLLi9sQ==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.37.tgz",
+      "integrity": "sha512-GTF2r1lP8nJBeA5Gxq5yZpJy9l8Fb9CXGZPfF8jHvaRdQHtm2Z+NDhqYmF833lcdkokRSyfPcXlz1mlWeClFpg==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "eventemitter3": "^3.1.0"
+        "any-promise": "1.3.0",
+        "eventemitter3": "1.1.1"
+      }
+    },
+    "web3-core-requestmanager": {
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.37.tgz",
+      "integrity": "sha512-66VUqye5BGp1Zz1r8psCxdNH+GtTjaFwroum2Osx+wbC5oRjAiXkkadiitf6wRb+edodjEMPn49u7B6WGNuewQ==",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-providers-http": "1.0.0-beta.37",
+        "web3-providers-ipc": "1.0.0-beta.37",
+        "web3-providers-ws": "1.0.0-beta.37"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.41.tgz",
-      "integrity": "sha512-kSaWfnDuPK3IQXMuNCixe7aq63qOBa2/21WKTpsXNA2yiwPBUmVylwiRMYwhf1ieZFPj9baEtVP8+0wxpXGE4g==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.37.tgz",
+      "integrity": "sha512-FdXl8so9kwkRRWziuCSpFsAuAdg9KvpXa1fQlT16uoGcYYfxwFO/nkwyBGQzkZt7emShI2IRugcazyPCZDwkOA==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "eventemitter3": "^3.1.0",
-        "lodash": "^4.17.11",
-        "web3-core-helpers": "1.0.0-beta.41",
-        "web3-utils": "1.0.0-beta.41"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
+        "eventemitter3": "1.1.1",
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.37"
       }
     },
     "web3-eth": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.41.tgz",
-      "integrity": "sha512-gLQaLB+aIr2iIU3eVMbsR1fMF38pgPaYeK0NvCuO0s87a/PrlEREwGxNQhxjAjZXFWgWGF1fQ2tiojP8toezrQ==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.37.tgz",
+      "integrity": "sha512-Eb3aGtkz3G9q+Z9DKgSQNbn/u8RtcZQQ0R4sW9hy5KK47GoT6vab5c6DiD3QWzI0BzitHzR5Ji+3VHf/hPUGgw==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "web3-core": "1.0.0-beta.41",
-        "web3-core-helpers": "1.0.0-beta.41",
-        "web3-core-method": "1.0.0-beta.41",
-        "web3-core-promievent": "1.0.0-beta.41",
-        "web3-core-subscriptions": "1.0.0-beta.41",
-        "web3-eth-abi": "1.0.0-beta.41",
-        "web3-eth-accounts": "1.0.0-beta.41",
-        "web3-eth-contract": "1.0.0-beta.41",
-        "web3-eth-ens": "1.0.0-beta.41",
-        "web3-eth-iban": "1.0.0-beta.41",
-        "web3-eth-personal": "1.0.0-beta.41",
-        "web3-net": "1.0.0-beta.41",
-        "web3-providers": "1.0.0-beta.41",
-        "web3-utils": "1.0.0-beta.41"
+        "underscore": "1.8.3",
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-eth-abi": "1.0.0-beta.37",
+        "web3-eth-accounts": "1.0.0-beta.37",
+        "web3-eth-contract": "1.0.0-beta.37",
+        "web3-eth-ens": "1.0.0-beta.37",
+        "web3-eth-iban": "1.0.0-beta.37",
+        "web3-eth-personal": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-eth-abi": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.41.tgz",
-      "integrity": "sha512-p/AcM7ASsYaHsqtR8vZD0tMQKnFC3ZMHYfI1HcEvyeMM3/hhLHPXIDGgqVVSTil5tJFz38YWzPGt/cWplIQPqw==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.37.tgz",
+      "integrity": "sha512-g9DKZGM2OqwKp/tX3W/yihcj7mQCtJ6CXyZXEIZfuDyRBED/iSEIFfieDOd+yo16sokLMig6FG7ADhhu+19hdA==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "ethers": "^4.0.0",
-        "lodash": "^4.17.11",
-        "web3-utils": "1.0.0-beta.41"
+        "ethers": "4.0.0-beta.1",
+        "underscore": "1.8.3",
+        "web3-utils": "1.0.0-beta.37"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        "@types/node": {
+          "version": "10.12.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.26.tgz",
+          "integrity": "sha512-nMRqS+mL1TOnIJrL6LKJcNZPB8V3eTfRo9FQA2b5gDvrHurC8XbSA86KNe0dShlEL7ReWJv/OU9NL7Z0dnqWTg=="
+        },
+        "ethers": {
+          "version": "4.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.1.tgz",
+          "integrity": "sha512-SoYhktEbLxf+fiux5SfCEwdzWENMvgIbMZD90I62s4GZD9nEjgEWy8ZboI3hck193Vs0bDoTohDISx84f2H2tw==",
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.3",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
         }
       }
     },
     "web3-eth-accounts": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.41.tgz",
-      "integrity": "sha512-+E+DIOF7B/dlln0aPh05FtYh1vk5oBd/bDOyXI4ki0R3L+1zGppUDxm7lOURqbYE0Ny5RFw4i8i1ygFNCTpBBw==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.37.tgz",
+      "integrity": "sha512-uvbHL62/zwo4GDmwKdqH9c/EgYd8QVnAfpVw8D3epSISpgbONNY7Hr4MRMSd/CqAP12l2Ls9JVQGLhhC83bW6g==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
+        "any-promise": "1.3.0",
         "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.8",
-        "lodash": "^4.17.11",
+        "eth-lib": "0.2.7",
         "scrypt.js": "0.2.0",
-        "uuid": "3.3.2",
-        "web3-core": "1.0.0-beta.41",
-        "web3-core-helpers": "1.0.0-beta.41",
-        "web3-core-method": "1.0.0-beta.41",
-        "web3-providers": "1.0.0-beta.41",
-        "web3-utils": "1.0.0-beta.41"
+        "underscore": "1.8.3",
+        "uuid": "2.0.1",
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       },
       "dependencies": {
+        "elliptic": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+          "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
         "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         }
       }
     },
     "web3-eth-contract": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.41.tgz",
-      "integrity": "sha512-irzF24h+R4nVOH5S54YwOBqyXGGJ/tj1SgW+cKRtUPzRdGTqefBv7jdMcpV7N7J0jZObfNxA5bnUBanvP/Ef0g==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.37.tgz",
+      "integrity": "sha512-h1B3A8Z/C7BlnTCHkrWbXZQTViDxfR12lKMeTkT8Sqj5phFmxrBlPE4ORy4lf1Dk5b23mZYE0r/IRACx4ThCrQ==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "lodash": "^4.17.11",
-        "web3-core": "1.0.0-beta.41",
-        "web3-core-helpers": "1.0.0-beta.41",
-        "web3-core-method": "1.0.0-beta.41",
-        "web3-core-promievent": "1.0.0-beta.41",
-        "web3-core-subscriptions": "1.0.0-beta.41",
-        "web3-eth-abi": "1.0.0-beta.41",
-        "web3-eth-accounts": "1.0.0-beta.41",
-        "web3-providers": "1.0.0-beta.41",
-        "web3-utils": "1.0.0-beta.41"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
+        "underscore": "1.8.3",
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-promievent": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-eth-abi": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-eth-ens": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.41.tgz",
-      "integrity": "sha512-bB/LME1//Hw9CGeKfl1D6LfLNoDZdESavzNMdXFukHqB7QtfC1ck6DzEz2TfHOIigoNy0XPPSBpqZH/LdrH8Nw==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.37.tgz",
+      "integrity": "sha512-dR3UkrVzdRrJhfP57xBPx0CMiVnCcYFvh+u2XMkGydrhHgupSUkjqGr89xry/j1T0BkuN9mikpbyhdCVMXqMbg==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
         "eth-ens-namehash": "2.0.8",
-        "lodash": "^4.17.11",
-        "web3-core": "1.0.0-beta.41",
-        "web3-core-helpers": "1.0.0-beta.41",
-        "web3-core-method": "1.0.0-beta.41",
-        "web3-core-promievent": "1.0.0-beta.41",
-        "web3-eth-abi": "1.0.0-beta.41",
-        "web3-eth-contract": "1.0.0-beta.41",
-        "web3-net": "1.0.0-beta.41",
-        "web3-providers": "1.0.0-beta.41",
-        "web3-utils": "1.0.0-beta.41"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
+        "underscore": "1.8.3",
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-promievent": "1.0.0-beta.37",
+        "web3-eth-abi": "1.0.0-beta.37",
+        "web3-eth-contract": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-eth-iban": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.41.tgz",
-      "integrity": "sha512-NbaBVApKIEB/1G0OVio0IOWmEvBM87lGO/bGB1xkH44GDdmBaLihBe7KoWcE81AEkBM3l24w7hPApOuD1qfUqg==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.37.tgz",
+      "integrity": "sha512-WQRniGJFxH/XCbd7miO6+jnUG+6bvuzfeufPIiOtCbeIC1ypp1kSqER8YVBDrTyinU1xnf1U5v0KBZ2yiWBJxQ==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "bn.js": "4.11.8",
-        "web3-utils": "1.0.0-beta.41"
+        "bn.js": "4.11.6",
+        "web3-utils": "1.0.0-beta.37"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
       }
     },
     "web3-eth-personal": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.41.tgz",
-      "integrity": "sha512-yBzw21B/F5ld7SCReBVk/fxGlQBaRYmC4/lqb1M1DoSI8xjVUF8tJuxbecGG8dofS5f86vmB+CEA1CdSiRx94A==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.37.tgz",
+      "integrity": "sha512-B4dZpGbD+nGnn48i6nJBqrQ+HB7oDmd+Q3wGRKOsHSK5HRWO/KwYeA7wgwamMAElkut50lIsT9EJl4Apfk3G5Q==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "web3-core": "1.0.0-beta.41",
-        "web3-core-helpers": "1.0.0-beta.41",
-        "web3-core-method": "1.0.0-beta.41",
-        "web3-net": "1.0.0-beta.41",
-        "web3-providers": "1.0.0-beta.41",
-        "web3-utils": "1.0.0-beta.41"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-net": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.41.tgz",
-      "integrity": "sha512-JbefIb0jas6HhkQFx24UzhX0cy4ZZdebNk6eqAQ9G8YDz9yq8Cc7FwVppZDQW7Ka+O7StpRLUzoxXIIeIfiSkA==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.37.tgz",
+      "integrity": "sha512-xG/uBtMdDa1UMXw9KjDUgf3fXA/fDEJUYUS0TDn+U9PMgngA+UVECHNNvQTrVVDxEky38V3sahwIDiopNsQdsw==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "lodash": "^4.17.11",
-        "web3-core": "1.0.0-beta.41",
-        "web3-core-helpers": "1.0.0-beta.41",
-        "web3-core-method": "1.0.0-beta.41",
-        "web3-providers": "1.0.0-beta.41",
-        "web3-utils": "1.0.0-beta.41"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
-    "web3-providers": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-providers/-/web3-providers-1.0.0-beta.41.tgz",
-      "integrity": "sha512-KTx9yw2inJwUvl5BDHzAYPQ5WmUAPaO/IxWHvS7WvPOCiQonq2HbSF9bOSl5uWkqWeqhIl0nUhGKU7ED5q6yLQ==",
+    "web3-providers-http": {
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.37.tgz",
+      "integrity": "sha512-FM/1YDB1jtZuTo78habFj7S9tNHoqt0UipdyoQV29b8LkGKZV9Vs3is8L24hzuj1j/tbwkcAH+ewIseHwu0DTg==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "@types/node": "^10.12.18",
-        "eventemitter3": "3.1.0",
-        "lodash": "^4.17.11",
-        "oboe": "2.1.4",
-        "url-parse": "1.4.4",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+        "web3-core-helpers": "1.0.0-beta.37",
         "xhr2-cookies": "1.1.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
+      }
+    },
+    "web3-providers-ipc": {
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.37.tgz",
+      "integrity": "sha512-NdRPRxYMIU0C3u18NI8u4bwbhI9pCg5nRgDGYcmSAx5uOBxiYcQy+hb0WkJRRhBoyIXJmy+s26FoH8904+UnPg==",
+      "requires": {
+        "oboe": "2.1.3",
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.37"
+      }
+    },
+    "web3-providers-ws": {
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.37.tgz",
+      "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       }
     },
     "web3-shh": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.41.tgz",
-      "integrity": "sha512-qFXmyAGh7oYizTv/vJWjMrSe5IMCBpU3IR1bliCd/GVqGKylH13N1oe8ifWk+EO8jPfFy7qWlJrbMKfAOAj2Lg==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.37.tgz",
+      "integrity": "sha512-h5STG/xqZNQWtCLYOu7NiMqwqPea8SfkKQUPUFxXKIPVCFVKpHuQEwW1qcPQRJMLhlQIv17xuoUe1A+RzDNbrw==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "web3-core": "1.0.0-beta.41",
-        "web3-core-helpers": "1.0.0-beta.41",
-        "web3-core-method": "1.0.0-beta.41",
-        "web3-core-subscriptions": "1.0.0-beta.41",
-        "web3-net": "1.0.0-beta.41",
-        "web3-providers": "1.0.0-beta.41",
-        "web3-utils": "1.0.0-beta.41"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37"
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.41.tgz",
-      "integrity": "sha512-6Vf+jzZEsYoAvECm+/mQx4L0p5eOxpDmbR7baFUZpB+DQyNFBc3XPSMUNWHBLqe/OpXjDrS2TeYv40Ai8bd4bg==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
+      "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "@types/node": "^10.12.18",
-        "bn.js": "4.11.8",
-        "eth-lib": "0.2.8",
-        "ethjs-unit": "^0.1.6",
-        "lodash": "^4.17.11",
+        "bn.js": "4.11.6",
+        "eth-lib": "0.1.27",
+        "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
         "randomhex": "0.1.5",
+        "underscore": "1.8.3",
         "utf8": "2.1.1"
       },
       "dependencies": {
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        },
-        "utf8": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
-          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
       }
     },
@@ -3470,75 +2956,10 @@
         }
       }
     },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "write-file-atomic": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
-      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
     },
     "ws": {
       "version": "3.3.3",
@@ -3549,11 +2970,6 @@
         "safe-buffer": "~5.1.0",
         "ultron": "~1.1.0"
       }
-    },
-    "xdg-basedir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
     "xhr": {
       "version": "2.5.0",
@@ -3588,11 +3004,6 @@
         "xhr-request": "^1.0.1"
       }
     },
-    "xhr2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
-    },
     "xhr2-cookies": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
@@ -3611,47 +3022,10 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
     "yaeti": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
       "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
-    },
-    "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
-    },
-    "yargs": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
-      "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
-      }
-    },
-    "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-      "requires": {
-        "camelcase": "^4.1.0"
-      }
     },
     "yauzl": {
       "version": "2.10.0",
@@ -3663,23 +3037,55 @@
       }
     },
     "zos-lib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/zos-lib/-/zos-lib-2.1.0.tgz",
-      "integrity": "sha512-HLjo31UKwjj1hbdyXuG7JM/UKVx/cmUh5BG9usguIrpueVDUWS60x/+k8JtVPv6214TLQTfZ/UJRReuDmMrnGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/zos-lib/-/zos-lib-2.2.0.tgz",
+      "integrity": "sha512-Hex60MlPT2AFE7G+MRxN/ip9tsVUNjOPOTvl81Qghh/ntLRvDNAxtYJaHxup3/F1xF0DuDBrYCHIRdXkR3rkXQ==",
       "requires": {
+        "@types/web3": "^1.0.14",
         "axios": "^0.18.0",
         "bignumber.js": "^7.2.0",
         "chalk": "^2.4.1",
-        "ethereumjs-abi": "^0.6.5",
+        "ethers": "^4.0.20",
         "glob": "^7.1.3",
+        "lodash.concat": "^4.5.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.every": "^4.6.0",
+        "lodash.findlast": "^4.6.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.includes": "^4.3.0",
+        "lodash.invertby": "^4.7.0",
+        "lodash.isarray": "^4.0.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isstring": "^4.0.1",
+        "lodash.keys": "^4.2.0",
+        "lodash.map": "^4.6.0",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "lodash.reverse": "^4.0.1",
+        "lodash.some": "^4.6.0",
+        "lodash.uniq": "^4.5.0",
+        "lodash.values": "^4.3.0",
+        "lodash.without": "^4.4.0",
         "openzeppelin-solidity": "~1.10.0",
         "semver": "^5.5.1",
-        "truffle-config": "1.0.6",
-        "truffle-contract": "3.0.6",
-        "truffle-flattener": "^1.2.8",
-        "truffle-provider": "0.0.6",
-        "truffle-provisioner": "0.1.1",
-        "web3": "^0.18.4"
+        "truffle-flattener": "^1.3.0",
+        "web3": "1.0.0-beta.37"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "dotenv": "^6.2.0",
     "openzeppelin-eth": "^2.1.3",
-    "truffle": "5.0.4",
     "truffle-hdwallet-provider": "^1.0.3",
     "zos-lib": "2.2.0"
   }

--- a/zos.json
+++ b/zos.json
@@ -1,0 +1,8 @@
+{
+  "zosversion": "2.2",
+  "name": "zepkit",
+  "version": "0.1.0",
+  "contracts": {
+    "Counter": "Counter"
+  }
+}

--- a/zos.json
+++ b/zos.json
@@ -1,8 +1,0 @@
-{
-  "zosversion": "2.2",
-  "name": "zepkit",
-  "version": "0.1.0",
-  "contracts": {
-    "Counter": "Counter"
-  }
-}


### PR DESCRIPTION
PR adds support for hot reloading of `.sol` files using webpack loader in order to speed up development and improve developer experience.

Features
* Allows importing `.sol` files directly into source code.
* Converts `.sol` files into `.json` using `compile`->`zos push`->`zos update`.
* Uses only development network, so won't run on any other networks.
* You can set the development network name using loader's config.
* Pulls build directory from truffle config.
* In case zos command not available, uses cached versions of .json files.
* Reports error to console output and dev tools.
* Compilation can be disabled using loader's disabled config.

[Zeppelin Solidity Hot Loader](https://github.com/ylv-io/zeppelin-solidity-hot-loader) is located in the separate GitHub repo, yet it is part of the PR because it is used as a loader in ZepKit.  [NPM package](https://www.npmjs.com/package/zeppelin-solidity-hot-loader) is published to enable `npm install command`.

Changes
* react-app-rewired package added in order to inject loader into CRA. config-overrides.js contains the loader config.
* ModuleScopePlugin disabled in order to allow import `.sol` files outside `src` directory.
* `require('Contract.json')` replaced with `require('Contract.sol')`
* Instructions page supplemented with additional instructions for Hot Reloading.
* truffle package removed due to the fact that ZepKit install instructions tell to run `npm install -g truffle@5.0.2 && npm install -g ganache-cli@6.3.0`

