### PR TITLE
fixes issue #32 and provides the correct HD wallet path for Ropsten i…

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -16,7 +16,9 @@ module.exports = {
     },
     ropsten: {
       provider: function() {
-        return new HDWalletProvider(mnemonic, 'https://ropsten.infura.io/v3/' + process.env.INFURA_API_KEY)
+        return new HDWalletProvider(mnemonic, 'https://ropsten.infura.io/v3/' + process.env.INFURA_API_KEY,
+            0, 1, true, "m/44'/1'/0'/0/"
+        )
       },
       network_id: '3',
       gas: 4465030,

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -26,21 +26,27 @@ module.exports = {
     },
     kovan: {
       provider: function() {
-        return new HDWalletProvider(mnemonic, 'https://kovan.infura.io/v3/' + process.env.INFURA_API_KEY)
+        return new HDWalletProvider(mnemonic, 'https://kovan.infura.io/v3/' + process.env.INFURA_API_KEY,
+            0, 1, true, "m/44'/1'/0'/0/"
+        )
       },
       network_id: '42',
       gas: 4465030,
       gasPrice: 10000000000,
     },
     rinkeby: {
-      provider: () => new HDWalletProvider(process.env.MNENOMIC, "https://rinkeby.infura.io/v3/" + process.env.INFURA_API_KEY),
+      provider: () => new HDWalletProvider(process.env.MNENOMIC, "https://rinkeby.infura.io/v3/" + process.env.INFURA_API_KEY,
+          0, 1, true, "m/44'/1'/0'/0/"
+      ),
       network_id: 4,
       gas: 3000000,
       gasPrice: 10000000000
     },
     // main ethereum network(mainnet)
     main: {
-      provider: () => new HDWalletProvider(process.env.MNENOMIC, "https://mainnet.infura.io/v3/" + process.env.INFURA_API_KEY),
+      provider: () => new HDWalletProvider(process.env.MNENOMIC, "https://mainnet.infura.io/v3/" + process.env.INFURA_API_KEY,
+          0, 1, true, "m/44'/1'/0'/0/"
+      ),
       network_id: 1,
       gas: 3000000,
       gasPrice: 10000000000


### PR DESCRIPTION
…n truffle-config

Fixes https://github.com/zeppelinos/zepkit/issues/32.

Actually this fix is required also on all other test networks as the HD derivation path for test networks is `m/44'/1'/0'/0` across all coins. But since I haven't tested it for Kovan and Rinkeby, I leave this as it is right now.

However, deployment on Ropsten needs the right derivation path when we want to be compatible to MyCrypto, MyEtherWallet and so on.