### PR TITLE
Fixes Doc Script

### DIFF
--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -8,17 +8,17 @@ fi
 set -o errexit
 
 if [ ! -d openzeppelin-docs ]; then
-  git clone https://github.com/frangio/openzeppelin-docs.git
+  git clone https://github.com/frangio/openzeppelin-docs.git openzeppelin-docs
 fi
 
 git -C openzeppelin-docs pull -q
 
 if [ "$1" = "build" ]; then
   cd docs
-  env DISABLE_PREPARE_DOCS= node ../docs.openzeppelin.com/build-local.js
+  env DISABLE_PREPARE_DOCS= node ../openzeppelin-docs/build-local.js
 
 elif [ "$1" = "start" ]; then
   npx concurrently \
-    'cd docs; nodemon -e adoc,yml ../docs.openzeppelin.com/build-local.js' \
-    'http-server -c-1 docs.openzeppelin.com/build/site'
+    'cd docs; nodemon -e adoc,yml ../openzeppelin-docs/build-local.js' \
+    'http-server -c-1 openzeppelin-docs/build/site'
 fi

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -15,10 +15,10 @@ git -C openzeppelin-docs pull -q
 
 if [ "$1" = "build" ]; then
   cd docs
-  env DISABLE_PREPARE_DOCS= node ../openzeppelin-docs/build-local.js
+  env DISABLE_PREPARE_DOCS= node ../docs.openzeppelin.com/build-local.js
 
 elif [ "$1" = "start" ]; then
   npx concurrently \
-    'cd docs; nodemon -e adoc,yml ../openzeppelin-docs/build-local.js' \
-    'http-server -c-1 openzeppelin-docs/build/site'
+    'cd docs; nodemon -e adoc,yml ../docs.openzeppelin.com/build-local.js' \
+    'http-server -c-1 docs.openzeppelin.com/build/site'
 fi


### PR DESCRIPTION
The new repo gets cloned by default into `docs.openzeppelin.com`