### PR TITLE
Fix/update global dependency versions#62

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ required to deploy to different networks.
 Install OpenZeppelin SDK, Ganache, and Truffle
 
 ```
-npm install -g truffle@5.0.2 ganache-cli@6.3.0 @openzeppelin/cli@2.5.0
+npm install -g truffle@5.0.41 ganache-cli@6.7.0 @openzeppelin/cli@2.5.3
 ```
 
 ## Installation

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -24,7 +24,7 @@ When interviewing developers building on OpenZeppelin tools, we found there was 
 Install OpenZeppelin SDK, Ganache, and Truffle.
 
 ``
-npm install -g truffle@5.0.2 ganache-cli@6.3.0 @openzeppelin/cli@2.5.1
+npm install -g truffle@5.0.41 ganache-cli@6.7.0 @openzeppelin/cli@2.5.3
 ``
 
 == How it works


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/starter-kit/issues/62

Update global dependency versions to:
```
npm install -g truffle@5.0.41 ganache-cli@6.7.0 @openzeppelin/cli@2.5.3
```