### PR TITLE
Hide localhost and metamask boxes if the connection is not available

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,28 +9,25 @@ const infuraToken = '95202223388e49f48b423ea50a70e336';
 
 function App() {
   const injected = useWeb3Injected();
+  const isHttp = window.location.protocol === 'http:';
   const local = useWeb3Network('http://127.0.0.1:8545');
-  let network;
-  network = useWeb3Network(`wss://ropsten.infura.io/ws/v3/${infuraToken}`, {
+  const network = useWeb3Network(`wss://ropsten.infura.io/ws/v3/${infuraToken}`, {
     pollInterval: 10 * 1000,
   });
 
   return (
-    <div className={styles.App}>
-      <br />
-      <h1>BUIDL with Starter Kit</h1>
-      <Web3Info title="Injected Web3" web3Context={injected} />
-      <br />
-      <Web3Info title="Local Web3 Node" web3Context={local} />
-      {infuraToken ? (
-        <React.Fragment>
-          <br />
+    <>
+      <h1>OpenZeppelin Starter Kit</h1>
+      <div className={styles.App}>
+        <Web3Info title="Injected Web3" web3Context={injected} />
+        {isHttp &&
+          <Web3Info title="Local Web3 Node" web3Context={local} />
+        }
+        {infuraToken &&
           <Web3Info title="Infura Web3" web3Context={network} />
-        </React.Fragment>
-      ) : (
-        <React.Fragment></React.Fragment>
-      )}
-    </div>
+        }
+      </div>
+    </>
   );
 }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -19,7 +19,9 @@ function App() {
     <>
       <h1>OpenZeppelin Starter Kit</h1>
       <div className={styles.App}>
-        <Web3Info title="Injected Web3" web3Context={injected} />
+        {injected &&
+          <Web3Info title="Wallet Web3" web3Context={injected} />
+        }
         {isHttp &&
           <Web3Info title="Local Web3 Node" web3Context={local} />
         }

--- a/client/src/App.module.scss
+++ b/client/src/App.module.scss
@@ -1,11 +1,21 @@
 @import './layout/variables.scss';
 
+h1 {
+  margin: auto;
+  margin: 20px auto;
+  text-align: center;
+}
+
 .App {
   text-align: center;
   display: flex;
-  flex-flow: column nowrap;
-  justify-content: flex-start;
-  align-items: center;
+  flex-flow: row wrap;
+  justify-content: center;
+  align-items: normal;
+}
+
+.App > div {
+  margin: 10px;
 }
 
 code {


### PR DESCRIPTION
When hosted on https, the http connection to localhost fails; this PR hides the localhost box if the site is not served via http. It also hides the web3Injected box if metamask is not present (though it requires https://github.com/OpenZeppelin/openzeppelin-network.js/pull/24 to be merged and network-js to be bumped).

This changeset also includes some minor layout improvements.